### PR TITLE
Search city names with a space

### DIFF
--- a/Clima/Model/WeatherManager.swift
+++ b/Clima/Model/WeatherManager.swift
@@ -19,10 +19,17 @@ struct WeatherManager {
     
     var delegate: WeatherManagerDelegate?
     
-    func fetchWeather(cityName: String) {
-        let urlString = "\(weatherURL)&q=\(cityName)"
-        performRequest(with: urlString)
-    }
+    //fetch weather by city names that contain a space
+       func fetchWeather(cityName: String){
+           let urlString: String
+           if(cityName.contains(" ")){
+               let cityNameWithSpace = (cityName as NSString).replacingOccurrences(of: " ", with: "+")
+               urlString = "\(weatherURL)&q=\(cityNameWithSpace)"
+           }else{
+               urlString = "\(weatherURL)&q=\(cityName)"
+           }
+           performRequest(with: urlString)
+       }
     
     func fetchWeather(latitude: CLLocationDegrees, longitude: CLLocationDegrees) {
         let urlString = "\(weatherURL)&lat=\(latitude)&lon=\(longitude)"


### PR DESCRIPTION
Before: You could not search for a city name with a space. For example, "Corte Madera" would not be searchable since the API URL could not update anything with a space. 

After:  Now you can search for cities that contain a space between them.  The API URL gets updated with a "+" wherever a " " is added allowing to fetch the city's weather information. 