### PR TITLE
Update WeatherManager.swift

### DIFF
--- a/Clima/Controller/WeatherManager.swift
+++ b/Clima/Controller/WeatherManager.swift
@@ -20,7 +20,7 @@ struct WeatherManager {
     var delegate: WeatherManagerDelegate?
     
     func fetchWeather(cityName: String) {
-        let urlString = "\(weatherURL)&q=\(cityName)"
+        let urlString = "\(weatherURL)&q=\(cityName)".trimmingCharacters(in: .whitespaces)
         performRequest(with: urlString)
     }
     


### PR DESCRIPTION
When using the keyboards autocompletion on City names it will postfix whitespace on the end of the string and will fail to create a valid URL.